### PR TITLE
Add split unsup component versions to pack.toml, disable Sodium's No Error Context by default

### DIFF
--- a/pack/config/sodium-options.json
+++ b/pack/config/sodium-options.json
@@ -1,0 +1,5 @@
+{
+  "performance": {
+    "use_no_error_g_l_context": false
+  }
+}

--- a/pack/pack.toml
+++ b/pack/pack.toml
@@ -10,7 +10,10 @@ hash-format = "sha256"
 [versions]
 fabric = "0.16.10"
 minecraft = "1.21.1"
-unsup = "1.1-pre6"
+unsup = "1.0.2"
+
+unsup-stable = "1.0.2"
+unsup-experimental = "1.1-pre6"
 
 [options]
 no-internal-hashes = true


### PR DESCRIPTION
New components for the new pack zip that has both unsup versions. I am not confident having everyone use 1.1 pre-releases at this juncture.

KHR_no_error is highly dangerous in a heavily modded environment as it can lead to impossible to debug crashes with no error messages, or complete corruption/flashing which can be dangerous for some people.