### PR TITLE
Fix OST resource pack being marked as incompatible

### DIFF
--- a/pack/resources/common/required/mf_music/pack.mcmeta
+++ b/pack/resources/common/required/mf_music/pack.mcmeta
@@ -1,6 +1,6 @@
 {
 	"pack": {
-		"pack_format": 48,
+		"pack_format": 34,
 		"description": "Event OST resources"
 	}
 }


### PR DESCRIPTION
`mf_music` is not a datapack and will be marked as incompatible if the value is `48` which translates to 1.21/1.21.1 pack.