### PR TITLE
Do not display realms notifications

### DIFF
--- a/pack/options.txt
+++ b/pack/options.txt
@@ -4,6 +4,7 @@ skipMultiplayerWarning:true
 joinedFirstServer:true
 tutorialStep:none
 renderDistance:32
+realmsNotifications:false
 key_key.advancements:key.keyboard.unknown
 key_key.waila.show_overlay:key.keyboard.right.alt
 key_axiom.keybind.toggle_replace_mode_cap:key.keyboard.unknown


### PR DESCRIPTION
The realms button has been replaced with the modpack credits button, therefore it makes no sense to have the notification icons from realms be displayed in title screen.