### PR TITLE
Remove usages of SHA-1

### DIFF
--- a/pack/mods/architectury-api.pw.toml
+++ b/pack/mods/architectury-api.pw.toml
@@ -4,8 +4,8 @@ side = "both"
 
 [download]
 url = "https://cdn.modrinth.com/data/lhGA9TYQ/versions/Wto0RchG/architectury-13.0.8-fabric.jar"
-hash-format = "sha1"
-hash = "e71346a43c563e5784580dd096338acfb45f49d4"
+hash-format = "sha512"
+hash = "7a24a0481732c5504b07347d64a2843c10c29e748018af8e5f5844e5ea2f4517433886231025d823f90eb0b0271d1fa9849c27e7b0c81476c73753f79f19302a"
 
 [update]
 [update.modrinth]

--- a/pack/mods/armorstandeditor.pw.toml
+++ b/pack/mods/armorstandeditor.pw.toml
@@ -4,8 +4,8 @@ side = "both"
 
 [download]
 url = "https://cdn.modrinth.com/data/Ef9ZREBZ/versions/b83teBdW/armor-stand-editor-2.5.1%2B1.21.1.jar"
-hash-format = "sha1"
-hash = "7df20eb466db9eedbe57c9a58375da65f3e119ba"
+hash-format = "sha512"
+hash = "5eff79aa747e74f6edac25fa19fc643ade12dc0cd83b7e5abbe3385705b50c2e39b48f30ca189a9b967074796579f0e53ad4ac889b7d5c8db833d19c8e99cdc0"
 
 [update]
 [update.modrinth]

--- a/pack/mods/badpackets.pw.toml
+++ b/pack/mods/badpackets.pw.toml
@@ -4,8 +4,8 @@ side = "both"
 
 [download]
 url = "https://cdn.modrinth.com/data/ftdbN0KK/versions/hjhT2sMz/badpackets-fabric-0.8.2.jar"
-hash-format = "sha1"
-hash = "5479129bfeaaad1ff2f8c5ebbda8a6dc7c4d7aaf"
+hash-format = "sha512"
+hash = "d156bd787c2f7b37314994b0f95f5a2edbee24f0f72459559d81ce7f77ba2ee01154d84fa3b7a670f21fb98c4b22df640e0f6d3def9d022c2f94889da0a31ac1"
 
 [update]
 [update.modrinth]

--- a/pack/mods/ballotbox.pw.toml
+++ b/pack/mods/ballotbox.pw.toml
@@ -4,8 +4,8 @@ side = "both"
 
 [download]
 url = "https://cdn.modrinth.com/data/6d6uwdZy/versions/V6mvS41D/ballotbox-0.5.4%2B1.21.jar"
-hash-format = "sha1"
-hash = "a85359efa1599a81c8993be954ca33017f8049b7"
+hash-format = "sha512"
+hash = "759a261cea0db7c9b96d020590e2e3c7d868222b12cf82409d85648d820b8f28da991eac2a761007eb67835a08ea53c080c6d550b87c6b6caacbf0061de3e37b"
 
 [update]
 [update.modrinth]

--- a/pack/mods/bobby.pw.toml
+++ b/pack/mods/bobby.pw.toml
@@ -4,8 +4,8 @@ side = "client"
 
 [download]
 url = "https://cdn.modrinth.com/data/M08ruV16/versions/oeSOphtG/bobby-5.2.4%2Bmc1.21.jar"
-hash-format = "sha1"
-hash = "dfa517fdb6e3fd2893f5d40f2c06cf01fb2a5db1"
+hash-format = "sha512"
+hash = "414436bf14ee9ad76ff2f849ffb5a2acda122a7588231d14dfbd27253924d08c22368c73ebd4b0048209d14682579be58743993265daaface4fdec6ec8e6e7ee"
 
 [update]
 [update.modrinth]

--- a/pack/mods/cloth-config.pw.toml
+++ b/pack/mods/cloth-config.pw.toml
@@ -4,8 +4,8 @@ side = "both"
 
 [download]
 url = "https://cdn.modrinth.com/data/9s6osm5g/versions/HpMb5wGb/cloth-config-15.0.140-fabric.jar"
-hash-format = "sha1"
-hash = "5d82342a2df53fd6df712bfdd583a811572918a4"
+hash-format = "sha512"
+hash = "1b3f5db4fc1d481704053db9837d530919374bf7518d7cede607360f0348c04fc6347a3a72ccfef355559e1f4aef0b650cd58e5ee79c73b12ff0fc2746797a00"
 
 [update]
 [update.modrinth]

--- a/pack/mods/ears.pw.toml
+++ b/pack/mods/ears.pw.toml
@@ -4,8 +4,8 @@ side = "client"
 
 [download]
 url = "https://cdn.modrinth.com/data/mfzaZK3Z/versions/sTb8pEOY/ears-fabric-1.21-1.4.6.jar"
-hash-format = "sha1"
-hash = "330ae7e417269c00db84b639316c61286c0e470a"
+hash-format = "sha512"
+hash = "045c831b561ee16cf38f89228b63565f325db757f9775e5c03167e47f67bc3421813560b51a0182db1a600a328ec6ff5c4b386d578972b23e451b3347ef9cd37"
 
 [update]
 [update.modrinth]

--- a/pack/mods/emi.pw.toml
+++ b/pack/mods/emi.pw.toml
@@ -4,8 +4,8 @@ side = "both"
 
 [download]
 url = "https://cdn.modrinth.com/data/fRiHVvU7/versions/HlidHIGb/emi-1.1.19%2B1.21.1%2Bfabric.jar"
-hash-format = "sha1"
-hash = "8c51af5fc515517ce523d55964a016d869a8555f"
+hash-format = "sha512"
+hash = "8ef84b0d215fed5bbbb2d8e8250fabca513d015da024f6bb8f0ceee37294bea4faf2db17c998a6afc43996f34d22cded8180eefe283b3c0b66a1cc4b3ec7e709"
 
 [update]
 [update.modrinth]

--- a/pack/mods/fabric-api.pw.toml
+++ b/pack/mods/fabric-api.pw.toml
@@ -4,8 +4,8 @@ side = "both"
 
 [download]
 url = "https://cdn.modrinth.com/data/P7dR8mSH/versions/9YVrKY0Z/fabric-api-0.115.0%2B1.21.1.jar"
-hash-format = "sha1"
-hash = "41594bd81f1e60e364f76b2e2bfca10cfdcf91bd"
+hash-format = "sha512"
+hash = "e5f3c3431b96b281300dd118ee523379ff6a774c0e864eab8d159af32e5425c915f8664b1cd576f20275e8baf995e016c5971fea7478c8cb0433a83663f2aea8"
 
 [update]
 [update.modrinth]

--- a/pack/mods/fabric-language-kotlin.pw.toml
+++ b/pack/mods/fabric-language-kotlin.pw.toml
@@ -4,8 +4,8 @@ side = "both"
 
 [download]
 url = "https://cdn.modrinth.com/data/Ha28R6CL/versions/476dzMG5/fabric-language-kotlin-1.13.1%2Bkotlin.2.1.10.jar"
-hash-format = "sha1"
-hash = "b28cc99b01aef86d0d6ca3ea7f468512bd0595c4"
+hash-format = "sha512"
+hash = "8e3609ef53a731c5509b304397e7fd4e37f2bbb4353b0d6234e74438846f0464743022f3339ba4f5acf21b023c80420ce59c194c1dfb11aeb79caffa6f842fb6"
 
 [update]
 [update.modrinth]

--- a/pack/mods/ferrite-core.pw.toml
+++ b/pack/mods/ferrite-core.pw.toml
@@ -4,8 +4,8 @@ side = "both"
 
 [download]
 url = "https://cdn.modrinth.com/data/uXXizFIs/versions/bwKMSBhn/ferritecore-7.0.2-hotfix-fabric.jar"
-hash-format = "sha1"
-hash = "48ee764932d0c8ec81a2223dbe333886938e512c"
+hash-format = "sha512"
+hash = "ca975bd3708cd96d30cf1447ac8883572113562eb2dd697e60c1cf382d6b70d0b1a511fcbfd042c51b2cf5d5ffc718b847f845e4c8a3e421e8c9ee741119a421"
 
 [update]
 [update.modrinth]

--- a/pack/mods/hoofprint.pw.toml
+++ b/pack/mods/hoofprint.pw.toml
@@ -4,8 +4,8 @@ side = "client"
 
 [download]
 url = "https://cdn.modrinth.com/data/8O6iJpuJ/versions/eQg3QhD8/hoofprint-0.6.1%2B1.21.jar"
-hash-format = "sha1"
-hash = "9c1bc3ed7c83ed6707ef710687bd1ad63d327c49"
+hash-format = "sha512"
+hash = "56eb86c75de52806dc228bb24d80762a5c9c177202a1788a6fb7151c0057b640b60490796a62237ab5b75785b171e1ffc795e1e2d082b9f09f3feb1dd42989e6"
 
 [update]
 [update.modrinth]

--- a/pack/mods/item-model-component-backport.pw.toml
+++ b/pack/mods/item-model-component-backport.pw.toml
@@ -3,5 +3,5 @@ filename = "item_model_component_backport-1.0.0.jar"
 
 [download]
 url = "https://github.com/ModFest/item-model-component-backport/releases/download/1.0.0/item_model_component_backport-1.0.0.jar"
-hash-format = "sha256"
-hash = "020e2ed7949f3128fdd91682cc5bbd14d607f70e28cd88d5f1c174e03b85b822"
+hash-format = "sha512"
+hash = "c8a1fc3a63f7b03a36539618225ed1f98df9ffeb3477036d04562314b467fe77b6e972e39b98ba66ca44788f4711015b073475ac96c9dd8bdbb80c829cb94b79"

--- a/pack/mods/jamlib.pw.toml
+++ b/pack/mods/jamlib.pw.toml
@@ -4,8 +4,8 @@ side = "both"
 
 [download]
 url = "https://cdn.modrinth.com/data/IYY9Siz8/versions/myXuhjoE/jamlib-fabric-1.2.2-build.2%2B1.21.1.jar"
-hash-format = "sha1"
-hash = "5bef1c21b9444bb136cf8bec61d134a430e1106e"
+hash-format = "sha512"
+hash = "7d3765c68c6752d5e7ab4cb50d78b388b97e5c87d15ceab8392177092eee3820bf1116008980cfbdb86c17a4fe57f930c634d87095a9d4dba60b528fdeecfaea"
 
 [update]
 [update.modrinth]

--- a/pack/mods/modernfix.pw.toml
+++ b/pack/mods/modernfix.pw.toml
@@ -4,8 +4,8 @@ side = "both"
 
 [download]
 url = "https://cdn.modrinth.com/data/nmDcB62a/versions/tn4FFqcg/modernfix-fabric-5.20.2%2Bmc1.21.1.jar"
-hash-format = "sha1"
-hash = "34f1cec6b5be986dac19db957d64f977489cad82"
+hash-format = "sha512"
+hash = "1ed6f19b08198d07b6a45a3fe6aaee01f420e70bc73c8cafd1be46ccea97584f407005395eb787b0c4a90e5d9ed9581938d9b335369468d1b05e935d7792e15a"
 
 [update]
 [update.modrinth]

--- a/pack/mods/modmenu.pw.toml
+++ b/pack/mods/modmenu.pw.toml
@@ -4,8 +4,8 @@ side = "client"
 
 [download]
 url = "https://cdn.modrinth.com/data/mOgUt4GM/versions/YIfqIJ8q/modmenu-11.0.3.jar"
-hash-format = "sha1"
-hash = "6213120772192040a0aeb5c7cfe330c068605b1f"
+hash-format = "sha512"
+hash = "4c6387a059c7ac9028acc3d78124af02a4495bef2c16783bbffe5bf449067daf2620708fd57f8725e46f0c34d0f571adf60f0869742bfe7f6101ddf13a2a87da"
 
 [update]
 [update.modrinth]

--- a/pack/mods/placeholder-api.pw.toml
+++ b/pack/mods/placeholder-api.pw.toml
@@ -4,8 +4,8 @@ side = "both"
 
 [download]
 url = "https://cdn.modrinth.com/data/eXts2L7r/versions/U5bhVym2/placeholder-api-2.4.2%2B1.21.jar"
-hash-format = "sha1"
-hash = "aa1b9a49f9f190dfe4825c502b150817dd2998c3"
+hash-format = "sha512"
+hash = "fc13d3a5c048dbaab86318edaf8b6c6b46ef9f1d367e8f063d19f5a9b0da66c5ae419d92c8c4608edc89a01eb44d91ffcf017fea73f39b222cbd85e82f70a233"
 
 [update]
 [update.modrinth]

--- a/pack/mods/player-roles.pw.toml
+++ b/pack/mods/player-roles.pw.toml
@@ -4,8 +4,8 @@ side = "server"
 
 [download]
 url = "https://cdn.modrinth.com/data/Rt1mrUHm/versions/Y5EAJzwR/player-roles-1.6.13.jar"
-hash-format = "sha1"
-hash = "e0322c75613085058c739b8d13e634235b9729a0"
+hash-format = "sha512"
+hash = "14cf8bb7da02fdb61765dd12b8f9fb0c92b5dfdce7d2b4068eb64735ddd97707e237d7845c4868acdabe2eb6b844f3d5cb525399571aa1eb007b4d521e5ffd15"
 
 [update]
 [update.modrinth]

--- a/pack/mods/qdwarp.pw.toml
+++ b/pack/mods/qdwarp.pw.toml
@@ -4,5 +4,5 @@ side = "both"
 
 [download]
 url = "https://github.com/ModFest/qdwarp/releases/download/v1.4.2%2B1.20/qdwarp-1.4.2+1.21.jar"
-hash-format = "sha256"
-hash = "de022dd279daa749c145b778ec3cf2ca8d93237b7ad00f3a363a183e36d1696f"
+hash-format = "sha512"
+hash = "a7674e0d1c0066471061ca23faefa257fa8f17b5ca20dae953f809d05bb797b51dd0072934d0b1d2ac556dae7bddd343b330583f72124e3109b90d97d97a3ee8"

--- a/pack/mods/quicker-connect-button.pw.toml
+++ b/pack/mods/quicker-connect-button.pw.toml
@@ -4,8 +4,8 @@ side = "client"
 
 [download]
 url = "https://cdn.modrinth.com/data/1SruaFxM/versions/5U7yVAq9/quickerconnectbutton-fabric-2.2.1%2B1.21.jar"
-hash-format = "sha1"
-hash = "ad6cfeb9186faf414c97dc9a7f613fe89f155e07"
+hash-format = "sha512"
+hash = "85f042484cc52ac8766d0cd745bcc10b126cbabfb1a762431e901fd2e798c610056f647b4351567195c50556611b1fee0f54302835c17b8a4f5d9d793c1ff18f"
 
 [update]
 [update.modrinth]

--- a/pack/mods/reeses-sodium-options.pw.toml
+++ b/pack/mods/reeses-sodium-options.pw.toml
@@ -4,8 +4,8 @@ side = "client"
 
 [download]
 url = "https://cdn.modrinth.com/data/Bh37bMuy/versions/KoUrx3jJ/reeses-sodium-options-fabric-1.8.3%2Bmc1.21.4.jar"
-hash-format = "sha1"
-hash = "c72f07a8f139f0420cbce29bd9eb29fb24db427f"
+hash-format = "sha512"
+hash = "42fd766fb3f4064938389599a53c3baad29e40e6ab9cdae9a4302eaa8b2daa96af9128978348549ef47122ecf2663b2e81e5155d01a4be4eba4d03c7e6974dba"
 
 [update]
 [update.modrinth]

--- a/pack/mods/scattered-shards.pw.toml
+++ b/pack/mods/scattered-shards.pw.toml
@@ -4,8 +4,8 @@ side = "both"
 
 [download]
 url = "https://cdn.modrinth.com/data/DB9GU3tx/versions/ASCau3rQ/scattered-shards-1.8.0%2B1.21.jar"
-hash-format = "sha1"
-hash = "3157819181670cb34206661176a2f7a900db15ec"
+hash-format = "sha512"
+hash = "3a660b116a6d8fe053f8d273f7706ed7b6a059251618342a8b7d2c8ebfcd787a39f846a1ca330fd452e8314bf9f3a3cbbb8195aedc0ddb000dc6b519a915b2f6"
 
 [update]
 [update.modrinth]

--- a/pack/mods/simple-voice-chat.pw.toml
+++ b/pack/mods/simple-voice-chat.pw.toml
@@ -4,8 +4,8 @@ side = "both"
 
 [download]
 url = "https://cdn.modrinth.com/data/9eGKb6K1/versions/d3r1NJxy/voicechat-fabric-1.21.1-2.5.27.jar"
-hash-format = "sha1"
-hash = "ae70dd73bef43a9629cefc0b23f4164eb5337a0d"
+hash-format = "sha512"
+hash = "e04c04a12e32b160d1deedd1e6d03ac7ed0432eeb1d226595422c8ef4436108492a2ec23c084bbb1934a9f05a68476321e802c9e30362c856bea9f0b056e70f8"
 
 [update]
 [update.modrinth]

--- a/pack/mods/simplefog.pw.toml
+++ b/pack/mods/simplefog.pw.toml
@@ -4,8 +4,8 @@ side = "client"
 
 [download]
 url = "https://cdn.modrinth.com/data/Glp1bwYc/versions/P12UZ38w/simplefog-1.6.0.jar"
-hash-format = "sha1"
-hash = "bb388df40ef063c0ba23c8f2b44a55c92494ed0f"
+hash-format = "sha512"
+hash = "a0bbf4015aa1aa2798a440ed91181afe3a7ba0831ba795aa79ad0ede6f5c9be3494af06a41a2801f6baee6550f46be805a37cc468cbdb04aff831dea69856e66"
 
 [update]
 [update.modrinth]

--- a/pack/mods/sodium.pw.toml
+++ b/pack/mods/sodium.pw.toml
@@ -4,8 +4,8 @@ side = "client"
 
 [download]
 url = "https://cdn.modrinth.com/data/AANobbMI/versions/EoNKHoLH/sodium-fabric-0.6.5%2Bmc1.21.1.jar"
-hash-format = "sha1"
-hash = "68469cfbcb1b7fcdb0d11c8b984a657adfac5684"
+hash-format = "sha512"
+hash = "d8979d318af75def36d60e823b50063a8f83bb22db602f04e4112a891eb564abd85c6c87a2ee6fad312c11703b3f586c6ca72f2ee13883a76ea3f655525603ee"
 
 [update]
 [update.modrinth]

--- a/pack/mods/spark.pw.toml
+++ b/pack/mods/spark.pw.toml
@@ -4,8 +4,8 @@ side = "both"
 
 [download]
 url = "https://cdn.modrinth.com/data/l6YH9Als/versions/cALUj9l1/spark-1.10.109-fabric.jar"
-hash-format = "sha1"
-hash = "eff42cbeee6fe9a7f3c57031c23200256366dcd1"
+hash-format = "sha512"
+hash = "367f574f6d28432067f09737577d799ced9c309c1725da1d09ffdfe10eacf461a66967205cc938131afbcc8b8255c8c25f8aa516e15f061c6481b6e7b8c94250"
 
 [update]
 [update.modrinth]

--- a/pack/mods/styled-chat.pw.toml
+++ b/pack/mods/styled-chat.pw.toml
@@ -4,8 +4,8 @@ side = "both"
 
 [download]
 url = "https://cdn.modrinth.com/data/doqSKB0e/versions/4e1xZSk3/styled-chat-2.6.1%2B1.21.jar"
-hash-format = "sha1"
-hash = "e6ab5db7b89994cb23e55de7f868731b22770a0b"
+hash-format = "sha512"
+hash = "cf46ed692a18396c12deb5842c9b04287d8127ba8d3e3604743dc774bf22cd860a5bba3d00377ad671c2e54942394ea99359b20e802e021802e8ab0491bec94c"
 
 [update]
 [update.modrinth]

--- a/pack/mods/surveyor.pw.toml
+++ b/pack/mods/surveyor.pw.toml
@@ -4,8 +4,8 @@ side = "both"
 
 [download]
 url = "https://cdn.modrinth.com/data/4KjqhPc9/versions/O3tZIYTa/surveyor-0.6.26%2B1.21.jar"
-hash-format = "sha1"
-hash = "cb25876e3ecd96e3df3be1d744d977a92bcc1fc4"
+hash-format = "sha512"
+hash = "d98d45206fd86c215d1e0aee4d63c49c33dd46ee45b58d9df373cd1a5c61f6747ed9651b5a42553ad5bccd313f1cbcd04d2aba0fff9f3114f6af34c31ab7a8a5"
 
 [update]
 [update.modrinth]

--- a/pack/mods/switchy-proxy.pw.toml
+++ b/pack/mods/switchy-proxy.pw.toml
@@ -4,8 +4,8 @@ side = "server"
 
 [download]
 url = "https://cdn.modrinth.com/data/6kt9OiyV/versions/bQl5d4QA/switchy-proxy-1.7.1%2B1.21.jar"
-hash-format = "sha1"
-hash = "e9dcb495b4382d57e299483365749c7dede660dc"
+hash-format = "sha512"
+hash = "b6682aff8d27902376a51dbfd55004fcd8e2a4523776023de12a15ed2216b3474cd4eb69fed90bed23f66ed7523e4434f7d22fef797af2692093fa08c6a4a7a5"
 
 [update]
 [update.modrinth]

--- a/pack/mods/switchy.pw.toml
+++ b/pack/mods/switchy.pw.toml
@@ -1,11 +1,11 @@
 name = "Switchy"
 filename = "switchy-2.9.7+1.21.jar"
-side = "both" # required for client
+side = "both"
 
 [download]
 url = "https://cdn.modrinth.com/data/ss0QuCRx/versions/jTmUcPg1/switchy-2.9.7%2B1.21.jar"
-hash-format = "sha1"
-hash = "5514d2f8446482e191e1729aff13c3f0b3c61691"
+hash-format = "sha512"
+hash = "5e8fe584a55ef80c3b5e21531b2f82ed78505740997a48f5ba1418acbde98ef4b8355bfb17b89ed9babea16aee9cc827c099d5885e1a50f75176530e2becc9b4"
 
 [update]
 [update.modrinth]

--- a/pack/mods/wthit.pw.toml
+++ b/pack/mods/wthit.pw.toml
@@ -4,8 +4,8 @@ side = "both"
 
 [download]
 url = "https://cdn.modrinth.com/data/6AQIaxuO/versions/njLybO11/wthit-fabric-12.5.1.jar"
-hash-format = "sha1"
-hash = "0687dce79dec6fca01c0e0f8ad83ab00d6b484fc"
+hash-format = "sha512"
+hash = "9247c7bd478dd65d3ea753236eb6cefe70cb92dab1638ed44dc4565fdd46d4937df6fc2b0376c8d9f5b778966b9f093731e6a082dd7935d186e6268bc6350d93"
 
 [update]
 [update.modrinth]


### PR DESCRIPTION
Generated by `packwiz rehash sha512`. Silences an unsup warning and is just good practice.

A bit of a nit, could be closed.