### PR TITLE
Update unsup-experimental to 1.1-pre7

### DIFF
--- a/pack/pack.toml
+++ b/pack/pack.toml
@@ -11,7 +11,7 @@ hash-format = "sha256"
 fabric = "0.16.10"
 minecraft = "1.21.1"
 unsup = "1.0.2"
-unsup-experimental = "1.1-pre6"
+unsup-experimental = "1.1-pre7"
 unsup-stable = "1.0.2"
 
 [options]


### PR DESCRIPTION
This fixes the nVidia EGL error some people have been seeing.