### PR TITLE
Do not enforce secure profiles

### DIFF
--- a/pack/server.properties
+++ b/pack/server.properties
@@ -2,6 +2,7 @@ motd=BlanketCon '25
 gamemode=adventure
 max-players=99
 enable-command-block=true
+enforce-secure-profile=false
 spawn-npcs=false
 spawn-animals=false
 spawn-monsters=false


### PR DESCRIPTION
Resolves an edge case where players can sometimes not chat properly when playing for extended periods of time until they relog.