### PR TITLE
Fix mod menu from overlapping other buttons

### DIFF
--- a/pack/config/modmenu.json
+++ b/pack/config/modmenu.json
@@ -1,0 +1,1 @@
+{"game_menu_button_style":"insert","mods_button_style": "replace_realms"}


### PR DESCRIPTION
Resolves this visual issue from occurring:
![a](https://github.com/user-attachments/assets/e40c5f87-29e5-417e-a0a2-71fa294b3394)
Also modfest is not realms compatible, therefore it should be made hidden just in case.