### PR TITLE
Disable messaging and typing effects by default.

### DIFF
--- a/pack/config/sounds/chat.json
+++ b/pack/config/sounds/chat.json
@@ -1,0 +1,26 @@
+{
+	"typingSoundEffect": {
+		"shouldPlay": false,
+		"pitch": 1.6,
+		"volume": 0.4,
+		"id": "typing",
+		"soundEvent": "minecraft:block.note_block.hat"
+	},
+	"messageSoundEffect": {
+		"shouldPlay": false,
+		"pitch": 2.0,
+		"volume": 0.8,
+		"id": "message",
+		"soundEvent": "minecraft:block.note_block.hat"
+	},
+	"mentionSoundEffect": {
+		"shouldPlay": true,
+		"pitch": 1.8,
+		"volume": 0.9,
+		"id": "mention",
+		"soundEvent": "minecraft:block.note_block.chime"
+	},
+	"ignoreSystemChats": true,
+	"enableChatSoundCooldown": true,
+	"chatSoundCooldown": 0.5
+}


### PR DESCRIPTION
Have kept mention pings enabled as they will be useful as chat will be too busy to notice if someone is trying to talk to you :)

Will not be disabling any of the other sounds as they're the primary showcase feature for the mod. Mod authors are welcome to add dynamic sound support for their modded items by following the docs, or using a datagen provider:

- https://docs.imb11.dev/sounds/data/dynamic-sounds (Items and Screens/Block Screens)
- https://github.com/IMB11/Sounds/blob/main/src/main/java/dev/imb11/sounds/api/datagen/SoundDefinitionProvider.java - Datagen for items/screen dynamic sound providers
- Example dynamic item sound datagen: https://github.com/IMB11/Sounds/blob/main/src/main/java/dev/imb11/sounds/loaders/fabric/datagen/DynamicItemSounds.java