### PR TITLE
Add Enchantment Descriptions as a base pack mod.

### DIFF
--- a/pack/config/enchdesc.json
+++ b/pack/config/enchdesc.json
@@ -1,0 +1,70 @@
+{
+  "enabled": {
+    "//": "Determines if the mod and its features are enabled.",
+    "//default": true,
+    "value": true
+  },
+  "only_on_books": {
+    "//": [
+      "When enabled, descriptions will only be displayed when looking at an enchanted  ",
+      "book.                                                                           "
+    ],
+    "//default": false,
+    "value": false
+  },
+  "only_in_enchanting_table": {
+    "//": [
+      "When enabled, descriptions will only be displayed when inside the enchanting    ",
+      "table GUI.                                                                      "
+    ],
+    "//default": false,
+    "value": false
+  },
+  "require_keybind": {
+    "//": [
+      "When enabled, descriptions will only be displayed when the user holds the shift ",
+      "key.                                                                            "
+    ],
+    "//default": false,
+    "value": true
+  },
+  "activate_text": {
+    "//": [
+      "This text will be displayed when the require_keybind option is enabled and the  ",
+      "user has not held the keybind.                                                  "
+    ],
+    "//default": {
+      "translate": "enchdesc.activate.message",
+      "color": "dark_gray"
+    },
+    "value": {
+      "translate": "enchdesc.activate.message",
+      "color": "dark_gray"
+    }
+  },
+  "prefix": {
+    "//": [
+      "Text that will be added to the start of each description. This can be used to   ",
+      "add indents and other decorators.                                               "
+    ],
+    "//default": "",
+    "value": ""
+  },
+  "suffix": {
+    "//": "Text that will be added to the end of each description.",
+    "//default": "",
+    "value": ""
+  },
+  "style": {
+    "//": [
+      "The style of the description text. This controls the color, format, font, and   ",
+      "other visual properties of the description.                                     "
+    ],
+    "//default": {
+      "color": "dark_gray"
+    },
+    "value": {
+      "color": "dark_gray"
+    }
+  }
+}

--- a/pack/index.toml
+++ b/pack/index.toml
@@ -23,6 +23,9 @@ file = "config/crunchy_crunchy_advancements.toml"
 file = "config/emi.css"
 
 [[files]]
+file = "config/enchdesc.json"
+
+[[files]]
 file = "config/familiar_friends.json"
 
 [[files]]
@@ -120,6 +123,10 @@ file = "mods/bobby.pw.toml"
 metafile = true
 
 [[files]]
+file = "mods/bookshelf-lib.pw.toml"
+metafile = true
+
+[[files]]
 file = "mods/cloth-config.pw.toml"
 metafile = true
 
@@ -137,6 +144,10 @@ metafile = true
 
 [[files]]
 file = "mods/emi.pw.toml"
+metafile = true
+
+[[files]]
+file = "mods/enchantment-descriptions.pw.toml"
 metafile = true
 
 [[files]]
@@ -226,6 +237,10 @@ metafile = true
 
 [[files]]
 file = "mods/polymer.pw.toml"
+metafile = true
+
+[[files]]
+file = "mods/prickle.pw.toml"
 metafile = true
 
 [[files]]

--- a/pack/mods/bookshelf-lib.pw.toml
+++ b/pack/mods/bookshelf-lib.pw.toml
@@ -1,0 +1,13 @@
+name = "Bookshelf"
+filename = "bookshelf-fabric-1.21.1-21.1.50.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/uy4Cnpcm/versions/U87GVHh9/bookshelf-fabric-1.21.1-21.1.50.jar"
+hash-format = "sha1"
+hash = "7ce43d58568eb958330a85c4ac28acdf69d4b2fd"
+
+[update]
+[update.modrinth]
+mod-id = "uy4Cnpcm"
+version = "U87GVHh9"

--- a/pack/mods/enchantment-descriptions.pw.toml
+++ b/pack/mods/enchantment-descriptions.pw.toml
@@ -1,0 +1,13 @@
+name = "Enchantment Descriptions"
+filename = "enchdesc-fabric-1.21.1-21.1.5.jar"
+side = "client"
+
+[download]
+url = "https://cdn.modrinth.com/data/UVtY3ZAC/versions/xUkDe05K/enchdesc-fabric-1.21.1-21.1.5.jar"
+hash-format = "sha1"
+hash = "11f11a5aceb6740b7a2ff2d8a8241137aa8b33d9"
+
+[update]
+[update.modrinth]
+mod-id = "UVtY3ZAC"
+version = "xUkDe05K"

--- a/pack/mods/prickle.pw.toml
+++ b/pack/mods/prickle.pw.toml
@@ -1,0 +1,13 @@
+name = "Prickle"
+filename = "prickle-fabric-1.21.1-21.1.6.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/aaRl8GiW/versions/aGDJh61g/prickle-fabric-1.21.1-21.1.6.jar"
+hash-format = "sha1"
+hash = "37a4d086303671e64baf8a2814e8c3e8326d16e2"
+
+[update]
+[update.modrinth]
+mod-id = "aaRl8GiW"
+version = "aGDJh61g"


### PR DESCRIPTION
Enchiridion probably should have this as a supplementary mod to help explain certain mechanics in a more accessible way than just putting it on a Glowcase text block.

Enchiridion does not have this feature built-in, because I wish to keep the mod as light and necessary as possible.