### PR TITLE
fix: Unignore worldinajar

### DIFF
--- a/platform.ignore
+++ b/platform.ignore
@@ -94,9 +94,6 @@ oceanic-weaponry
 # Parsing error loading recipe healpgood:polished_heart_crystal_stairsb_stonecutter | Not a JSON object: "healpgood:polished_heart_crystal_slab"
 # healing-pretty-good
 
-# Double reload
-worldinajar
-
 # Detected setBlock in a far chunk [-33, -16], pos: class_2338{x=-525, y=12, z=-241}, status: minecraft:features, currently generating: ResourceKey[minecraft:worldgen/placed_feature / wwizardry:crystal_shard/large/ceiling/diamond]
 wandering-wizardry
 


### PR DESCRIPTION
The double reload has been fixed in the latest update.