### PR TITLE
Do not show the magic bar unless required

### DIFF
--- a/pack/config/magiclib.json
+++ b/pack/config/magiclib.json
@@ -1,0 +1,3 @@
+{
+  "renderManaBar": "When_Needed"
+}


### PR DESCRIPTION
The magic bar covers up the offhand slot when playing left handed and should not be shown by default unless required for a reason.