### PR TITLE
Add lecterns to restricted blocks

### DIFF
--- a/pack/resources/datapack/required/mf_fireblanket/data/fireblanket/tags/block/block_interaction_restricted.json
+++ b/pack/resources/datapack/required/mf_fireblanket/data/fireblanket/tags/block/block_interaction_restricted.json
@@ -15,6 +15,7 @@
 		"minecraft:dropper",
 		"minecraft:hopper",
 		"minecraft:crafter",
+		"minecraft:lectern",
 		"map_utils:variable_redstone_block"
 	]
 }


### PR DESCRIPTION
This prevents players from taking books out of lecterns in adventure mode. It also prevents them from opening the GUI though - making it so you're only able to read the book in the world. A more complicated fix would be needed to prevent specifically the take book interaction, I can look into that if needed.