### PR TITLE
configs for chitinous ties

### DIFF
--- a/pack/config/chitinous_ties.json5
+++ b/pack/config/chitinous_ties.json5
@@ -1,0 +1,6 @@
+{
+	"chunkload": false,
+	"contract_capacity": 7,
+	"max_signs": 8,
+	"max_criteria": 64
+}

--- a/pack/config/crunchy_crunchy_advancements.toml
+++ b/pack/config/crunchy_crunchy_advancements.toml
@@ -8,7 +8,7 @@ preventAdvancementBroadcasts = true
 # default: BLACKLIST
 filterMode = "WHITELIST"
 # Namespaces to be entirely filtered, e.g. 'minecraft' or 'antique_atlas'
-filterNamespaces = ["cerulean"]
+filterNamespaces = ["cerulean", "chitinous_ties"]
 # Namespace-inclusive paths to be filtered, e.g. 'minecraft:recipes/' or 'tconstruct:foundry/'
 filterPaths = []
 # Whether to filter advancements that are triggered when obtaining a recipe, used for recipe advancements


### PR DESCRIPTION
the crunchy crunchy config's necessary for chitinous ties to work properly. the chitinous ties config itself is just to better optimize into the server env