### PR TITLE
Switch crawling from toggle -> hold

### DIFF
--- a/pack/config/getDown.json5
+++ b/pack/config/getDown.json5
@@ -1,0 +1,1 @@
+{"crawlToggled": false}


### PR DESCRIPTION
This is to remain consistent with vanilla's default sprinting and sneaking configuration as seen in accessibility settings.