### PR TITLE
Remove update labels + Snapper button in-game

### DIFF
--- a/pack/config/modmenu.json
+++ b/pack/config/modmenu.json
@@ -1,1 +1,1 @@
-{"game_menu_button_style":"insert","mods_button_style": "replace_realms"}
+{"game_menu_button_style":"insert","mods_button_style": "replace_realms","update_checker": false,"button_update_badge": false}

--- a/pack/config/snapper.json
+++ b/pack/config/snapper.json
@@ -1,0 +1,1 @@
+{"showSnapperGameMenu": false}


### PR DESCRIPTION
1. The update labels in Mod Menu are not required as the blanketcon modpack is controlled by the unsup software itself which can read the hashes off the github repositories for any changes made to it.
2. Snapper covers up the "X votes available!" text when pressing ESC key while inside any world.