### PR TITLE
Add demobox

### DIFF
--- a/pack/index.toml
+++ b/pack/index.toml
@@ -134,6 +134,10 @@ file = "mods/crunchy-crunchy-advancements.pw.toml"
 metafile = true
 
 [[files]]
+file = "mods/demobox.pw.toml"
+metafile = true
+
+[[files]]
 file = "mods/drogstyle.pw.toml"
 metafile = true
 

--- a/pack/mods/demobox.pw.toml
+++ b/pack/mods/demobox.pw.toml
@@ -1,0 +1,13 @@
+name = "DemoBox"
+filename = "DemoBox-1.1.0+mc.1.21.1.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/b2SVO5sB/versions/jbL1R7aO/DemoBox-1.1.0%2Bmc.1.21.1.jar"
+hash-format = "sha512"
+hash = "5970a51975fd0c4b6f15ef0e3f024d06cd3fac56bffd12806b526efd029a741bd25277a8fd4bc9c394ee860b084c1f7c2d0c15239f03771d035827c553cc02f0"
+
+[update]
+[update.modrinth]
+mod-id = "b2SVO5sB"
+version = "jbL1R7aO"


### PR DESCRIPTION
[Demobox](https://modrinth.com/mod/demobox) is a mod originally created by me for Blanketcon '23. It allows for the creation of interactive showcase worlds independent of the main con world. Here mods can show off features that would be unsafe in a shared world, such as ones requiring survival or creative mode. The mod is based on the same tech as nucleiod minigames, which fully isolates the player data in the virtual world.