### PR TITLE
Reset Yeet keybind to default

### DIFF
--- a/pack/options.txt
+++ b/pack/options.txt
@@ -163,7 +163,6 @@ key_key.waila.show_overlay:key.keyboard.unknown
 key_key.waila.toggle_liquid:key.keyboard.unknown
 key_key.waila.show_recipe_input:key.keyboard.unknown
 key_key.waila.show_recipe_output:key.keyboard.unknown
-key_key.yeet.yeet:key.keyboard.unknown
 key_key.zeldacraft.trinketneck:key.keyboard.unknown
 key_iris.keybind.reload:key.keyboard.unknown
 key_iris.keybind.toggleShaders:key.keyboard.unknown


### PR DESCRIPTION
Throwing was broken because of a conflict with Don't Do That, which is fixed in 1.1.1.
The default is supposed to overlap with drop (Q), tap does normal and hold does yeet.