### PR TITLE
Update Fabric Tailor to use MerchantCalico fix on GitHub.

### DIFF
--- a/pack/mods/fabrictailor.pw.toml
+++ b/pack/mods/fabrictailor.pw.toml
@@ -1,13 +1,14 @@
-name = "Fabric Tailor"
-filename = "fabrictailor-2.5.0.jar"
-side = "both"
+name = "fabrictailor"
+filename = "fabrictailor-2.5.0+bc25.1.jar"
 
 [download]
-url = "https://cdn.modrinth.com/data/g8w1NapE/versions/UDZdkBPN/fabrictailor-2.5.0.jar"
-hash-format = "sha512"
-hash = "df73fb7a9c8c54c12dda30cb1a7479e324a3ed8e0d4d5553f746e73760433bee4f56048d56236b372675364f1e5e4569fd9ff34a9ba7940f634387ad2d2bf0f8"
+url = "https://github.com/MerchantCalico/FabricTailor/releases/download/2.5.0%2Bbc25.1/fabrictailor-2.5.0+bc25.1.jar"
+hash-format = "sha256"
+hash = "fa7fd2dd222f44c238a935a1c93ee19a13caf16fee3efdcfb5de756f26073bb3"
 
 [update]
-[update.modrinth]
-mod-id = "g8w1NapE"
-version = "UDZdkBPN"
+[update.github]
+branch = "modfest/25"
+regex = "^\\.jar$"
+slug = "MerchantCalico/fabrictailor"
+tag = "2.5.0+bc25.1"


### PR DESCRIPTION
- Fixes skin upload/URL for Fabric Tailor.