### PR TITLE
Removed Bombs from loot grass loot table

### DIFF
--- a/pack/resources/datapack/required/legendofsteve/data/zeldacraft/loot_table/blocks/loot_grass.json
+++ b/pack/resources/datapack/required/legendofsteve/data/zeldacraft/loot_table/blocks/loot_grass.json
@@ -1,0 +1,39 @@
+{
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"rolls": 1,
+			"entries": [
+				{
+					"type": "minecraft:item",
+					"name": "zeldacraft:emerald_shard",
+					"weight": 100
+				},
+				{
+					"type": "minecraft:item",
+					"name": "minecraft:arrow",
+					"weight": 100
+				},
+				{
+					"type": "minecraft:item",
+					"name": "zeldacraft:magic_jar",
+					"weight": 40
+				},
+				{
+					"type": "minecraft:item",
+					"name": "zeldacraft:emerald_chunk",
+					"weight": 5
+				}
+			],
+			"conditions": [
+				{
+					"condition": "minecraft:block_state_property",
+					"block": "zeldacraft:loot_grass",
+					"properties": {
+						"age": "1"
+					}
+				}
+			]
+		}
+	]
+}

--- a/pack/resources/datapack/required/legendofsteve/pack.mcmeta
+++ b/pack/resources/datapack/required/legendofsteve/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+	"pack": {
+		"description": "Removes bombs from some loot tables to prevent destruction",
+		"pack_format": 48
+	}
+}


### PR DESCRIPTION
Bombs break cracked bricks which can be bad, so removed them from loot grass table