### PR TITLE
Disable stellaris earth sky

### DIFF
--- a/pack/config/sky-aesthetics.json
+++ b/pack/config/sky-aesthetics.json
@@ -1,0 +1,5 @@
+{
+  "disabledSkies": [
+    "stellaris:earth_sky"
+  ]
+}


### PR DESCRIPTION
This PR fix two issues : 

- Rods from Gods : the stellar objects couldn't change sizes
- Starcaller : Sky Aesthetics changed star rendering. Now, It will use vanilla method.
