### PR TITLE
tweak: Add Sky Block to #worldinajar:blocks/naughty_blocks

### DIFF
--- a/pack/resources/datapack/required/worldinajar_tweaks/data/worldinajar/tags/block/naughty_blocks.json
+++ b/pack/resources/datapack/required/worldinajar_tweaks/data/worldinajar/tags/block/naughty_blocks.json
@@ -1,0 +1,9 @@
+{
+	"values": [
+		{
+			"id": "affinity:the_sky",
+			"required": false
+		}
+	]
+}
+


### PR DESCRIPTION
This PR fulfills the requirement for World In a Jar, adding the `naughty_blocks` tag for configuration purposes. This is to prevent specific blocks (such as Sky Blocks) from rendering inside or outside a World Jar.