### PR TITLE
Allow team members to create new World Jars

### DIFF
--- a/pack/config/roles.json
+++ b/pack/config/roles.json
@@ -13,7 +13,8 @@
             "entity_selectors": true,
             "commands": {
 				".*": "allow"
-            }
+            },
+			"worldinajar:create_jar": true
         }
     },
     "participant": {

--- a/pack/config/roles.json
+++ b/pack/config/roles.json
@@ -14,7 +14,7 @@
             "commands": {
 				".*": "allow"
             },
-			"worldinajar:create_jar": true
+            "worldinajar:create_jar": true
         }
     },
     "participant": {


### PR DESCRIPTION
This is necessary for building purposes. World Jars are good for snowglobe-like builds. At most, participants will need one or *maybe* two unique World Jars. World Jars can be created by placing a new one from the creative menu.

From Discord:
> For builders: When you place a jar, a new ID gets assigned to it. Each jar has a unique ID which is what determines what's inside it. Here is the syntax for how to get a Jar of a specific ID. Do note that placing a jar from the creative inventory will create a new jar ID.
> In this case, the ID is `2`.
> `/give @s worldinajar:world_jar[worldinajar:jar_entry={id:2}]`
> 
> Jars are also locked by default to prevent people from entering showcase builds. If you want to unlock it, use the Lock item in Glowcase.
> 
> This will be useful for those who want to use World Jars to showcase builds.