### PR TITLE
Restrict interactions for specific blocks with Fireblanket.

### DIFF
--- a/pack/resources/datapack/required/restricted_interactions/data/fireblanket/tags/block/block_interaction_restricted.json
+++ b/pack/resources/datapack/required/restricted_interactions/data/fireblanket/tags/block/block_interaction_restricted.json
@@ -1,0 +1,11 @@
+{
+    "values": [
+        "minecraft:cake",
+        "#minecraft:candle_cakes",
+        "bovinesandbuttercups:placeable_edible",
+        "trickster:charging_array",
+        "trickster:modular_spell_construct",
+        "trickster:scroll_shelf",
+        "trickster:spell_construct"
+    ]
+}

--- a/pack/resources/datapack/required/restricted_interactions/pack.mcmeta
+++ b/pack/resources/datapack/required/restricted_interactions/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "description": "Restricts Interactions using Fireblanket",
+    "pack_format": 48
+  }
+}


### PR DESCRIPTION
Restricts the following blocks' interactions.

Trickster has been added to this PR with permission from the dev.
If you use Cake in your booth, please tell me and I'll revert the cake change, if you have an item that needs restricting, please tell me and I'll add it to this PR.

- Cake
- Cakes with Candles
- Bovines and Buttercups' Cupcakes and Mushroom Tarts
- Trickster's Charging Array
- Trickster's Modular Spell Construct
- Trickster's Scroll Shelf
- Trickster's Spell Construct