### PR TITLE
Fix netherite scrap and add advancement for default components shard

### DIFF
--- a/pack/config/crunchy_crunchy_advancements.toml
+++ b/pack/config/crunchy_crunchy_advancements.toml
@@ -8,7 +8,7 @@ preventAdvancementBroadcasts = true
 # default: BLACKLIST
 filterMode = "WHITELIST"
 # Namespaces to be entirely filtered, e.g. 'minecraft' or 'antique_atlas'
-filterNamespaces = ["cerulean", "chitinous_ties"]
+filterNamespaces = ["cerulean", "chitinous_ties", "default_components"]
 # Namespace-inclusive paths to be filtered, e.g. 'minecraft:recipes/' or 'tconstruct:foundry/'
 filterPaths = []
 # Whether to filter advancements that are triggered when obtaining a recipe, used for recipe advancements

--- a/pack/resources/datapack/required/default_components_demo/data/default_components/advancement/draft.json
+++ b/pack/resources/datapack/required/default_components_demo/data/default_components/advancement/draft.json
@@ -1,0 +1,29 @@
+{
+  "display": {
+    "icon": {
+      "id": "minecraft:carrot"
+    },
+    "title": "",
+    "description": "",
+    "show_toast": false,
+    "announce_to_chat": false,
+    "hidden": true
+  },
+  "criteria": {
+    "a": {
+      "trigger": "minecraft:consume_item",
+      "conditions": {
+        "item": {
+          "items": "#trickster:mana_knots"
+        }
+      }
+    }
+  },
+  "requirements": [
+    [
+      "a"
+    ]
+  ],
+  "rewards": {},
+  "sends_telemetry_event": false
+}

--- a/pack/resources/datapack/required/default_components_demo/data/default_components/function/mana_knot_shard.mcfunction
+++ b/pack/resources/datapack/required/default_components_demo/data/default_components/function/mana_knot_shard.mcfunction
@@ -1,0 +1,1 @@
+shard award @s decorative:durian

--- a/pack/resources/datapack/required/default_components_demo/data/minecraft/default_components/netherite_scrap.json
+++ b/pack/resources/datapack/required/default_components_demo/data/minecraft/default_components/netherite_scrap.json
@@ -6,7 +6,7 @@
                 "trickster"
             ]
         }
-    ]
+    ],
   "add": {
     "trickster:spell": {
       "value": [


### PR DESCRIPTION
The advancement is just to trigger the function that grants the player the shard
I wasn't able to test it on single player as for some reason /shard wasn't working