### PR TITLE
Add Affinity config and enable "Unfinished Features"

### DIFF
--- a/pack/config/affinity.json5
+++ b/pack/config/affinity.json5
@@ -1,0 +1,4 @@
+{
+	"unfinishedFeatures": true
+}
+


### PR DESCRIPTION
This allows us to use Villager Armatures in the booth - they are not actually really unfinished anymore, they simply haven't been removed from that tag yet