### PR TITLE
Add initial pvp island loot tables

### DIFF
--- a/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/common.json
+++ b/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/common.json
@@ -15,7 +15,26 @@
       "entries": [
         {
           "type": "minecraft:loot_table",
-          "value": "bc25:chests/common_ammo"
+          "value": "bc25:chests/common_ammo",
+          "weight": 1
+        },
+        {
+          "type": "minecraft:empty",
+          "weight": 2
+        }
+      ]
+    },
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:loot_table",
+          "value": "bc25:chests/common_omni_ammo",
+          "weight": 1
+        },
+        {
+          "type": "minecraft:empty",
+          "weight": 2
         }
       ]
     },

--- a/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/common.json
+++ b/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/common.json
@@ -1,0 +1,32 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:loot_table",
+          "value": "bc25:chests/common_weapons"
+        }
+      ]
+    },
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:loot_table",
+          "value": "bc25:chests/common_ammo"
+        }
+      ]
+    },
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:loot_table",
+          "value": "bc25:chests/food"
+        }
+      ]
+    }
+  ]
+}

--- a/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/common_ammo.json
+++ b/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/common_ammo.json
@@ -10,7 +10,11 @@
           "functions": [
             {
               "function": "minecraft:set_count",
-              "count": 8
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 6,
+                "max": 10
+              }
             }
           ]
         },
@@ -20,7 +24,11 @@
           "functions": [
             {
               "function": "minecraft:set_count",
-              "count": 16
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 12,
+                "max": 20
+              }
             }
           ]
         },
@@ -30,7 +38,11 @@
           "functions": [
             {
               "function": "minecraft:set_count",
-              "count": 8
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 6,
+                "max": 10
+              }
             }
           ]
         },
@@ -40,7 +52,11 @@
           "functions": [
             {
               "function": "minecraft:set_count",
-              "count": 8
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 6,
+                "max": 10
+              }
             }
           ]
         },
@@ -50,7 +66,11 @@
           "functions": [
             {
               "function": "minecraft:set_count",
-              "count": 16
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 12,
+                "max": 20
+              }
             }
           ]
         }

--- a/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/common_ammo.json
+++ b/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/common_ammo.json
@@ -1,0 +1,60 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:spectral_arrow",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 8
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:arrow",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 16
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "fletching-expanded:frost_arrow",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 8
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "fletching-expanded:flame_arrow",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 8
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "fletching-expanded:iron_arrow",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 16
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/common_omni_ammo.json
+++ b/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/common_omni_ammo.json
@@ -26,6 +26,16 @@
         },
         {
           "type": "minecraft:item",
+          "name": "minecraft:breeze_rod",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 4
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
           "name": "minecraft:honey_bottle",
           "functions": [
             {
@@ -51,6 +61,26 @@
             {
               "function": "minecraft:set_count",
               "count": 1
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:pufferfish",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 1
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:salmon_bucket",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 2
             }
           ]
         }

--- a/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/common_omni_ammo.json
+++ b/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/common_omni_ammo.json
@@ -1,0 +1,60 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:slime_ball",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 6
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:blaze_powder",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:honey_bottle",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 4
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:gunpowder",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 6
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:pumpkin",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/common_weapons.json
+++ b/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/common_weapons.json
@@ -76,6 +76,20 @@
         {
           "type": "minecraft:item",
           "name": "festive_frenzy:sharpened_candy_cane"
+        },
+        {
+          "type": "minecraft:item",
+          "name": "extravaganza:golden_festive_coin",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 12,
+                "max": 24
+              }
+            }
+          ]
         }
       ]
     }

--- a/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/common_weapons.json
+++ b/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/common_weapons.json
@@ -1,0 +1,82 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:crossbow",
+          "functions": [
+            {
+              "function": "minecraft:set_components",
+              "components": {
+                "minecraft:enchantments": {
+                  "omnicrossbow:omni": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "pierced:long_crossbow"
+        },
+        {
+          "type": "minecraft:item",
+          "name": "hibernalherbs:syrum_sword"
+        },
+        {
+          "type": "minecraft:item",
+          "name": "hibernalherbs:arkonium_sword"
+        },
+        {
+          "type": "minecraft:item",
+          "name": "cerulean:fuchsia_sword"
+        },
+        {
+          "type": "minecraft:item",
+          "name": "ubesdelight:rolling_pin_wood"
+        },
+        {
+          "type": "minecraft:item",
+          "name": "farmersdelight:skillet"
+        },
+        {
+          "type": "minecraft:item",
+          "name": "basicweapons:bronze_dagger"
+        },
+        {
+          "type": "minecraft:item",
+          "name": "basicweapons:bronze_quarterstaff"
+        },
+        {
+          "type": "minecraft:item",
+          "name": "snapshot_mc:hammer"
+        },
+        {
+          "type": "minecraft:item",
+          "name": "basicweapons:iron_hammer"
+        },
+        {
+          "type": "minecraft:item",
+          "name": "festive_frenzy:frostflake_cannon",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 6,
+                "max": 10
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "festive_frenzy:sharpened_candy_cane"
+        }
+      ]
+    }
+  ]
+}

--- a/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/common_weapons.json
+++ b/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/common_weapons.json
@@ -12,7 +12,8 @@
               "function": "minecraft:set_components",
               "components": {
                 "minecraft:enchantments": {
-                  "omnicrossbow:omni": 1
+                  "omnicrossbow:omni": 1,
+                  "omnicrossbow:multichambered": 3
                 }
               }
             }

--- a/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/food.json
+++ b/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/food.json
@@ -1,0 +1,122 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "farmersdelight:hamburger",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 5,
+                "max": 9
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "farmersdelight:fruit_salad",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 6,
+                "max": 10
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "farmersdelight:bacon_sandwich",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 3,
+                "max": 7
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "farmersdelight:dumplings",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 2,
+                "max": 4
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "farmersdelight:stuffed_potato",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 2,
+                "max": 4
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "farmersdelight:cabbage_rolls",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 3,
+                "max": 5
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "farmersdelight:salmon_roll",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 1,
+                "max": 3
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "farmersdelight:cod_roll",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 3,
+                "max": 6
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/rare.json
+++ b/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/rare.json
@@ -15,7 +15,26 @@
       "entries": [
         {
           "type": "minecraft:loot_table",
-          "value": "bc25:chests/food"
+          "value": "bc25:chests/rare_omni_ammo",
+          "weight": 1
+        },
+        {
+          "type": "minecraft:empty",
+          "weight": 2
+        }
+      ]
+    },
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:loot_table",
+          "value": "bc25:chests/food",
+          "weight": 1
+        },
+        {
+          "type": "minecraft:empty",
+          "weight": 1
         }
       ]
     }

--- a/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/rare.json
+++ b/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/rare.json
@@ -1,0 +1,23 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:loot_table",
+          "value": "bc25:chests/rare_weapons"
+        }
+      ]
+    },
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:loot_table",
+          "value": "bc25:chests/food"
+        }
+      ]
+    }
+  ]
+}

--- a/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/rare_omni_ammo.json
+++ b/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/rare_omni_ammo.json
@@ -1,0 +1,30 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:echo_shard",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:nether_star",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/rare_weapons.json
+++ b/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/rare_weapons.json
@@ -1,0 +1,60 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "lilium:discharge_cannon",
+          "functions": [
+            {
+              "function": "minecraft:set_components",
+              "components": {
+                "lilium:discharge_cannon_charge_level": 1
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "affinity:azalea_bow"
+        },
+        {
+          "type": "minecraft:item",
+          "name": "oxide:pure_nail"
+        },
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:leather_boots",
+          "functions": [
+            {
+              "function": "minecraft:set_components",
+              "components": {
+                "minecraft:attribute_modifiers": {
+                  "modifiers": [
+                    {
+                      "type": "necessities:max_jumps",
+                      "amount": 4,
+                      "operation": "add_value",
+                      "id": "minecraft:1744783545173",
+                      "slot": "feet"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "spirit_vector:spirit_vector"
+        },
+        {
+          "type": "minecraft:item",
+          "name": "soteria:soterian_lance"
+        }
+      ]
+    }
+  ]
+}

--- a/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/uncommon.json
+++ b/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/uncommon.json
@@ -1,0 +1,32 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:loot_table",
+          "value": "bc25:chests/uncommon_weapons"
+        }
+      ]
+    },
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:loot_table",
+          "value": "bc25:chests/uncommon_ammo"
+        }
+      ]
+    },
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:loot_table",
+          "value": "bc25:chests/food"
+        }
+      ]
+    }
+  ]
+}

--- a/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/uncommon.json
+++ b/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/uncommon.json
@@ -15,7 +15,26 @@
       "entries": [
         {
           "type": "minecraft:loot_table",
-          "value": "bc25:chests/uncommon_ammo"
+          "value": "bc25:chests/uncommon_ammo",
+          "weight": 1
+        },
+        {
+          "type": "minecraft:empty",
+          "weight": 2
+        }
+      ]
+    },
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:loot_table",
+          "value": "bc25:chests/uncommon_omni_ammo",
+          "weight": 1
+        },
+        {
+          "type": "minecraft:empty",
+          "weight": 2
         }
       ]
     },

--- a/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/uncommon_ammo.json
+++ b/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/uncommon_ammo.json
@@ -1,0 +1,80 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "fletching-expanded:echo_arrow",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 6,
+                "max": 10
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "fletching-expanded:homing_arrow",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 2,
+                "max": 4
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "fletching-expanded:phantom_arrow",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 6,
+                "max": 10
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "fletching-expanded:slime_arrow",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 10,
+                "max": 20
+              }
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "fletching-expanded:amethyst_arrow",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 6,
+                "max": 10
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/uncommon_omni_ammo.json
+++ b/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/uncommon_omni_ammo.json
@@ -1,0 +1,70 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:blaze_rod",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 4
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:end_crystal",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:ender_eye",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 1
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:tnt",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 2
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:wither_skeleton_skull",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 4
+            }
+          ]
+        },
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:dragon_breath",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/uncommon_weapons.json
+++ b/pack/resources/datapack/required/pvpisland_loot/data/bc25/loot_table/chests/uncommon_weapons.json
@@ -1,0 +1,54 @@
+{
+  "type": "minecraft:chest",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "pierced:harpoon_crossbow"
+        },
+        {
+          "type": "minecraft:item",
+          "name": "hibernalherbs:slowness_herbal_blend"
+        },
+        {
+          "type": "minecraft:item",
+          "name": "hibernalherbs:mining_fatigue_herbal_blend"
+        },
+        {
+          "type": "minecraft:item",
+          "name": "hibernalherbs:speed_herbal_blend"
+        },
+        {
+          "type": "minecraft:item",
+          "name": "hibernalherbs:night_vision_herbal_blend"
+        },
+        {
+          "type": "minecraft:item",
+          "name": "amarong:amarong_hammer"
+        },
+        {
+          "type": "minecraft:item",
+          "name": "basicweapons:diamond_hammer"
+        },
+        {
+          "type": "minecraft:item",
+          "name": "klaxon:steel_hammer"
+        },
+        {
+          "type": "minecraft:item",
+          "name": "taccorpstrinkets:quartzite_hammer"
+        },
+        {
+          "type": "minecraft:item",
+          "name": "pierced:harpoon"
+        },
+        {
+          "type": "minecraft:item",
+          "name": "basicweapons:netherite_club"
+        }
+      ]
+    }
+  ]
+}

--- a/pack/resources/datapack/required/pvpisland_loot/pack.mcmeta
+++ b/pack/resources/datapack/required/pvpisland_loot/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+    "pack": {
+        "description": "PVP Island Chest Loot",
+        "pack_format": 48
+    }
+}


### PR DESCRIPTION
I created scripts to generate these loot tables so they can easily be tweaked in the future
https://github.com/ThePotatoArchivist/bc25loot/
It's also easier to view the loot distribution there

Probably will require further balancing revisions but this can be the initial version