### PR TITLE
Do not show lmft's in-game error

### DIFF
--- a/pack/config/lmft.json
+++ b/pack/config/lmft.json
@@ -1,0 +1,3 @@
+{
+  "disableIngameError": true
+}


### PR DESCRIPTION
This error should not be shown unless debugging is required for a reason.