### PR TITLE
Add Enchiridion anti-smuggle datapack for tool chamber.

### DIFF
--- a/pack/resources/datapack/required/enchiridion_anti_smuggle/data/enchiridion/enchantment/prospector.json
+++ b/pack/resources/datapack/required/enchiridion_anti_smuggle/data/enchiridion/enchantment/prospector.json
@@ -1,0 +1,68 @@
+{
+    "anvil_cost": 4,
+    "description": {
+        "translate": "enchantment.enchiridion.prospector"
+    },
+    "effects": {
+        "enchiridion:block_loot": [
+            {
+                "effect": {
+                    "table": "enchiridion:prospector_digging"
+                },
+                "requirements": {
+                    "condition": "minecraft:all_of",
+                    "terms": [
+                        {
+                            "condition": "enchiridion:block_params",
+                            "predicate": {
+                                "blocks": "#enchiridion:can_prospect"
+                            }
+                        },
+                        {
+                            "chance": {
+                                "type": "minecraft:enchantment_level",
+                                "amount": {
+                                    "type": "minecraft:linear",
+                                    "base": 0.04,
+                                    "per_level_above_first": 0.02
+                                }
+                            },
+                            "condition": "minecraft:random_chance"
+                        }
+                    ]
+                }
+            }
+        ],
+        "enchiridion:run_functions_on_block_loot": [
+            {
+                "effect": {
+                    "functions": [
+                        {
+                            "function": "minecraft:set_components",
+                            "components": {
+                                "area_tools:dissolve": {
+                                    "area_id": "enchiridion:prospector"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "exclusive_set": "#minecraft:exclusive_set/mining",
+    "max_cost": {
+        "base": 65,
+        "per_level_above_first": 9
+    },
+    "max_level": 3,
+    "min_cost": {
+        "base": 15,
+        "per_level_above_first": 9
+    },
+    "slots": [
+        "mainhand"
+    ],
+    "supported_items": "#enchiridion:enchantable/shovel",
+    "weight": 2
+}

--- a/pack/resources/datapack/required/enchiridion_anti_smuggle/data/enchiridion/enchantment/splitting.json
+++ b/pack/resources/datapack/required/enchiridion_anti_smuggle/data/enchiridion/enchantment/splitting.json
@@ -1,0 +1,63 @@
+{
+    "anvil_cost": 4,
+    "description": {
+        "translate": "enchantment.enchiridion.splitting"
+    },
+    "effects": {
+        "enchiridion:run_functions_on_block_loot": [
+            {
+                "effect": {
+                    "functions": [
+                        {
+                            "function": "enchiridion:split_to_planks"
+                        },
+                        {
+                            "add": true,
+                            "count": {
+                                "type": "minecraft:enchantment_level",
+                                "amount": {
+                                    "type": "minecraft:linear",
+                                    "base": 4.0,
+                                    "per_level_above_first": 1.0
+                                }
+                            },
+                            "function": "minecraft:set_count"
+                        },
+                        {
+                            "function": "minecraft:set_components",
+                            "components": {
+                                "area_tools:dissolve": {
+                                    "area_id": "enchiridion:tool_chamber"
+                                }
+                            }
+                        }
+                    ],
+                    "predicate": {
+                        "items": "#enchiridion:can_split"
+                    }
+                },
+                "requirements": {
+                    "condition": "enchiridion:block_params",
+                    "predicate": {
+                        "blocks": "#enchiridion:can_split"
+                    }
+                }
+            }
+        ]
+    },
+    "exclusive_set": "#minecraft:exclusive_set/mining",
+    "max_cost": {
+        "base": 65,
+        "per_level_above_first": 9
+    },
+    "max_level": 2,
+    "min_cost": {
+        "base": 15,
+        "per_level_above_first": 9
+    },
+    "slots": [
+        "mainhand"
+    ],
+    "supported_items": "#enchiridion:enchantable/axe",
+    "weight": 2
+}

--- a/pack/resources/datapack/required/enchiridion_anti_smuggle/pack.mcmeta
+++ b/pack/resources/datapack/required/enchiridion_anti_smuggle/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+	"pack": {
+		"description": "Anti-smuggle for Enchiridion booth areas.",
+		"pack_format": 48
+	}
+}


### PR DESCRIPTION
Sets the items dropped by items with the Splitting and Prospector enchantments to dissolve outside of their respective showcase areas.