### PR TITLE
Disable sync-chunk-writes for server

### DIFF
--- a/pack/server.properties
+++ b/pack/server.properties
@@ -6,3 +6,4 @@ enforce-secure-profile=false
 spawn-npcs=true
 spawn-animals=true
 spawn-monsters=false
+sync-chunk-writes=false


### PR DESCRIPTION
Leaving it enabled causes an issue where the fabric server would hang for multiple seconds upon stopping the server via UNIX.