### PR TITLE
Add Scriptor and Alchimiae Demo Packs

### DIFF
--- a/pack/resources/datapack/required/alchimiae_demo/data/alchimiae/alchimiae/custom_effects/shard.json
+++ b/pack/resources/datapack/required/alchimiae_demo/data/alchimiae/alchimiae/custom_effects/shard.json
@@ -1,0 +1,7 @@
+{
+  "category": "NEUTRAL",
+  "tick_frequency": 100,
+  "tick_commands": [
+    "shard award @s alchimiae:modfest_dragonfruit"
+  ]
+}

--- a/pack/resources/datapack/required/alchimiae_demo/pack.mcmeta
+++ b/pack/resources/datapack/required/alchimiae_demo/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+	"pack": {
+		"pack_format": 48,
+		"description": "Demo pack for Alchimiae Magicae"
+	}
+}

--- a/pack/resources/datapack/required/scriptor_demo/data/scriptor/scriptor/actions/give_shard.json
+++ b/pack/resources/datapack/required/scriptor_demo/data/scriptor/scriptor/actions/give_shard.json
@@ -1,0 +1,13 @@
+{
+    "cost": 0.1,
+    "disabled": false,
+    "cast_at_position": [
+      "shard award @caster scriptor:modfest_dragonfruit"
+    ],
+    "cast_on_entity": [
+      "shard award @caster scriptor:modfest_dragonfruit"
+    ],
+    "cast_on_item": [
+      "shard award @caster scriptor:modfest_dragonfruit"
+    ]
+  }

--- a/pack/resources/datapack/required/scriptor_demo/data/scriptor/tags/block/do_not_phase.json
+++ b/pack/resources/datapack/required/scriptor_demo/data/scriptor/tags/block/do_not_phase.json
@@ -1,0 +1,6 @@
+{
+    "replace": true,
+    "values": [
+      "scriptor:black_magic_block"
+    ]
+  }

--- a/pack/resources/datapack/required/scriptor_demo/pack.mcmeta
+++ b/pack/resources/datapack/required/scriptor_demo/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+	"pack": {
+		"pack_format": 48,
+		"description": "Demo pack for Scriptor Magicae"
+	}
+}


### PR DESCRIPTION
Replaces the inverted phase tag with a single block for demo purposes and adds a custom spell action and potion effect for awarding shards.