### PR TITLE
[FallFlyingRestrictions] Disabled config entry for item usage

### DIFF
--- a/pack/config/fallflyingrestrictions.json5
+++ b/pack/config/fallflyingrestrictions.json5
@@ -1,0 +1,27 @@
+{
+	displayWarning: {
+		badWeatherCondition: true,
+		flyingTooHigh: true,
+		blockedInventory: true,
+		blockedEating: true,
+		blockedItemUsage: false,
+		zoneTakeOff: true,
+		zoneFlying: true,
+	},
+	toggleFeatures: {
+		movementChanges: true,
+		flightHeightAboveGroundSafety: true,
+		flyingTooHigh: false,
+		roofAboveHeadSafety: true,
+		inventoryBlock: true,
+		eatingBlock: false,
+		itemUsageBlock: false,
+	},
+	// Restriction Values will only be considered if their corresponding features are enabled
+	restrictionValues: {
+		badWeatherDownForce: 0.05,
+		flyingTooHighDownForce: 0.08,
+		safeAboveGroundHeight: 5,
+		flyingHeightLimit: 300,
+	},
+}


### PR DESCRIPTION
Added config for FFR to enable item usage while fall flying.

This has been done to make Lashing Potato from [Necessities](https://github.com/ItsFelix5/Necessities) usable, as requested by @ItsFelix5 