### PR TITLE
fix: Don't instance Affinity's sky

### DIFF
--- a/pack/resources/datapack/required/vanillin_ban/data/vanillin/tags/item/no_instancing.json
+++ b/pack/resources/datapack/required/vanillin_ban/data/vanillin/tags/item/no_instancing.json
@@ -1,6 +1,7 @@
 {
 	"values": [
 		"#affinity:staffs",
+		"affinity:the_sky",
 		"#petworks:collars",
 		"primordia:stormweaver",
 		"#festive_frenzy:sharpened_candy_canes",


### PR DESCRIPTION
This causes the sky to render as stone.