### PR TITLE
[FallFlyingRestrictions] Updated for Global restrictions

### DIFF
--- a/pack/config/fallflyingrestrictions.json5
+++ b/pack/config/fallflyingrestrictions.json5
@@ -4,7 +4,7 @@
 		flyingTooHigh: true,
 		blockedInventory: true,
 		blockedEating: true,
-		blockedItemUsage: true,
+		blockedItemUsage: false,
 		zoneTakeOff: true,
 		zoneFlying: true,
 	},

--- a/pack/config/fallflyingrestrictions.json5
+++ b/pack/config/fallflyingrestrictions.json5
@@ -4,7 +4,7 @@
 		flyingTooHigh: true,
 		blockedInventory: true,
 		blockedEating: true,
-		blockedItemUsage: false,
+		blockedItemUsage: true,
 		zoneTakeOff: true,
 		zoneFlying: true,
 	},
@@ -16,6 +16,7 @@
 		inventoryBlock: true,
 		eatingBlock: false,
 		itemUsageBlock: false,
+		rocketUsageBlock: false,
 	},
 	// Restriction Values will only be considered if their corresponding features are enabled
 	restrictionValues: {
@@ -23,5 +24,10 @@
 		flyingTooHighDownForce: 0.08,
 		safeAboveGroundHeight: 5,
 		flyingHeightLimit: 300,
+	},
+	// Global settings are overruled by manually specified local zones
+	globalZoneRestrictions: {
+		preventStartFlying: true,
+		interruptFlying: true,
 	},
 }


### PR DESCRIPTION
In 1.0.2, new global settings were added.

Only accept this pull request if FFR version 1.0.2 is being used!
https://discord.com/channels/674795434509598731/1363627925114589386/1365071881509671012

---

Also note, that this config applies new flying settings globally! Any other booth which relies on elytra flying needs to specify its local zones!

This is **_not_** done with Area-lib.
For that, the `/flying zone restriction ...` commands need to be used instead!