### PR TITLE
Add custom oxide biome

### DIFF
--- a/pack/resources/datapack/required/oxide_biome_pack/data/minecraft/worldgen/biome/oxide_wasteland.json
+++ b/pack/resources/datapack/required/oxide_biome_pack/data/minecraft/worldgen/biome/oxide_wasteland.json
@@ -1,0 +1,16 @@
+{
+  "carvers": {},
+  "downfall": 0.9,
+  "effects": {
+    "fog_color": 4541247,
+    "foliage_color": 5852994,
+    "sky_color": 9016695,
+    "water_color": 8288095,
+    "water_fog_color": 3155745
+  },
+  "features": [],
+  "has_precipitation": true,
+  "spawn_costs": {},
+  "spawners": {},
+  "temperature": 0.8
+}

--- a/pack/resources/datapack/required/oxide_biome_pack/pack.mcmeta
+++ b/pack/resources/datapack/required/oxide_biome_pack/pack.mcmeta
@@ -1,0 +1,10 @@
+{
+	"pack": {
+		"pack_format": 48,
+		"supported_formats": {
+			"min_inclusive": 48,
+			"max_inclusive": 71
+		},
+		"description": "Oxide biome tint datapack"
+	}
+}


### PR DESCRIPTION
a custom biome with a nice water color for the oxide booth that prevents swamp fireflies from spawning there