### PR TITLE
Update HAPPY to 0.0.5

### DIFF
--- a/pack/mods/have-another-pretty-particle-yayyyyyyyy.pw.toml
+++ b/pack/mods/have-another-pretty-particle-yayyyyyyyy.pw.toml
@@ -1,13 +1,13 @@
 name = "Have Another Pretty Particle. Yayyyyyyyy"
-filename = "happy-0.0.4.jar"
+filename = "happy-0.0.5.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/KVSwjhVT/versions/86RBG5eq/happy-0.0.4.jar"
+url = "https://cdn.modrinth.com/data/KVSwjhVT/versions/w9ULu8u8/happy-0.0.5.jar"
 hash-format = "sha512"
-hash = "8800731f104256587d61c037ca9840779d9d496dce9e6d7bf57abdcbafe39824d9b431c0fc43e54b13128004d45f156690ae00e4b02a5949894955b2b52a2502"
+hash = "62a13e77a92b71ef89ba2bbd6b1bd16f1b141c0690f4836635e64e0c607e4214cf00053f03116e1cc0f5d4be6c0ad95d5d107ae34a8a2df4aa93047662809896"
 
 [update]
 [update.modrinth]
 mod-id = "KVSwjhVT"
-version = "86RBG5eq"
+version = "w9ULu8u8"


### PR DESCRIPTION
**This merges into main!!** Please look over real quick to confirm its good. I did *(finally)* learn how to setup a local unsup instance (after 40 minutes of floundering ontop of my couple hours of floundering the other day), and confirmed it works on the client. 

Updates HAPPY to 0.0.5 for compat. with Explosive Enhancement for showcasing. Only update server + pack when you would've done it anyways(basically, don't restart the server _just_ for this).