### PR TITLE
fix: Typo in Enchiridion Combat Vault loot table.

### DIFF
--- a/pack/resources/datapack/required/enchiridion_combat_trial_minigame/data/blanketcon25/loot_table/enchiridion/combat_chamber_vault.json
+++ b/pack/resources/datapack/required/enchiridion_combat_trial_minigame/data/blanketcon25/loot_table/enchiridion/combat_chamber_vault.json
@@ -95,7 +95,7 @@
                             }
                         }
                     ],
-                    "name": "miencraft:lapis_lazuili",
+                    "name": "minecraft:lapis_lazuli",
                     "weight": 2
                 },
                 {


### PR DESCRIPTION
Fixes a typo that prevented the loot table from working.